### PR TITLE
Update 1.21.1 port for Create 6.0.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
         type: choice
         description: Platform
         options:
-          - all
-          - fabric
           - neoforge
 
 permissions:
@@ -17,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: mcr.microsoft.com/openjdk/jdk:17-ubuntu
+      image: mcr.microsoft.com/openjdk/jdk:21-ubuntu
       options: --user root
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out
 # gradle
 build
 .gradle
+/dist/
 
 # other
 eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id "architectury-plugin" version "3.4-SNAPSHOT"
-  id "dev.architectury.loom" version "1.11-SNAPSHOT" apply false
-  id "io.github.p03w.machete" version "1.+" // automatic jar compressing on build
+  id "architectury-plugin" version "3.4.164"
+  id "dev.architectury.loom" version "1.11.458" apply false
+  id "io.github.p03w.machete" version "1.2.0" // automatic jar compressing on build
   id "me.modmuss50.mod-publish-plugin" version "0.7.4" apply false
 }
 
@@ -91,6 +91,9 @@ allprojects {
   }
 
   java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(21)
+    }
     withSourcesJar()
   }
 
@@ -112,6 +115,31 @@ tasks.create("publishTramways") {
       dependsOn "${platform}:build", "${platform}:publishMods"
       break
   }
+}
+
+// The root project has no mod sources. Do not emit empty jars that can be
+// mistaken for the installable NeoForge artifact.
+tasks.named("jar") {
+  enabled = false
+}
+
+tasks.named("sourcesJar") {
+  enabled = false
+}
+
+tasks.register("packageNeoForge", Copy) {
+  dependsOn(":neoforge:remapJar")
+  from(project(":neoforge").tasks.named("remapJar").flatMap { it.archiveFile })
+  into(layout.projectDirectory.dir("dist"))
+  rename { "create-tramways-${mod_version}-mc${minecraft_version}-neoforge.jar" }
+}
+
+tasks.named("build") {
+  dependsOn("packageNeoForge")
+}
+
+tasks.named("clean") {
+  delete(layout.projectDirectory.dir("dist"))
 }
 
 tasks.register('javadocAll', Javadoc) {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,8 +24,8 @@ dependencies {
 
   // Compat
   //modCompileOnly("com.railwayteam.railways:Steam_Rails-common-${minecraft_version}:${railways_common_version}") { transitive = false }
-  modCompileOnly("maven.modrinth:create-railways-navigator:${crn_fabric_version}")
-  modCompileOnly("de.mrjulsen.mcdragonlib:dragonlib-fabric:${minecraft_version}-${dragonlib_version}")
+  compileOnly("maven.modrinth:create-railways-navigator:${crn_neoforge_version}") { transitive = false }
+  compileOnly("de.mrjulsen.mcdragonlib:dragonlib-neoforge:${minecraft_version}-${dragonlib_version}") { transitive = false }
 }
 
 sourceSets {

--- a/common/src/main/java/purplecreate/tramways/TTags.java
+++ b/common/src/main/java/purplecreate/tramways/TTags.java
@@ -44,20 +44,20 @@ public class TTags {
   private static void genBlockTags(RegistrateTagsProvider<Block> p) {
     TagGen.CreateTagsProvider<Block> provider = new TagGen.CreateTagsProvider<>(p, Block::builtInRegistryHolder);
 
-    provider.tag(SIGNAL_POLE)
-      .add(
-        TBlocks.TRAM_SIGNAL.get(),
-        TBlocks.TRAM_SIGN.get(),
-        TBlocks.RAILWAY_SIGN.get(),
-        AllBlocks.METAL_GIRDER.get(),
-        AllBlocks.METAL_GIRDER_ENCASED_SHAFT.get()
-      )
-      .addOptional(Mods.RAILWAYS.rl("semaphore"))
-      .addTag(BlockTags.FENCES);
+    TagGen.CreateTagAppender<Block> signalPoles = provider.tag(SIGNAL_POLE);
+    signalPoles.add(
+      TBlocks.TRAM_SIGNAL.get(),
+      TBlocks.TRAM_SIGN.get(),
+      TBlocks.RAILWAY_SIGN.get(),
+      AllBlocks.METAL_GIRDER.get(),
+      AllBlocks.METAL_GIRDER_ENCASED_SHAFT.get()
+    );
+    signalPoles.addOptional(Mods.RAILWAYS.rl("semaphore"));
+    signalPoles.addTag(BlockTags.FENCES);
 
-    provider.tag(NAME_SIGN_INNER)
-      .add(Blocks.NETHER_BRICKS)
-      .addTag(BlockTags.PLANKS);
+    TagGen.CreateTagAppender<Block> nameSignInner = provider.tag(NAME_SIGN_INNER);
+    nameSignInner.add(Blocks.NETHER_BRICKS);
+    nameSignInner.addTag(BlockTags.PLANKS);
 
     provider.tag(SEMAPHORE_POLE)
       .add(

--- a/common/src/main/java/purplecreate/tramways/compat/createrailwaysnavigator/CRNTrainInfo.java
+++ b/common/src/main/java/purplecreate/tramways/compat/createrailwaysnavigator/CRNTrainInfo.java
@@ -7,12 +7,11 @@ import de.mrjulsen.crn.data.TrainLine;
 import de.mrjulsen.crn.data.train.TrainData;
 import de.mrjulsen.crn.data.train.TrainListener;
 import de.mrjulsen.crn.data.train.TrainPrediction;
-// import de.mrjulsen.crn.util.ETimeFormat;
-// import de.mrjulsen.mcdragonlib.util.time.ConfiguredTimeSystem;
-// import de.mrjulsen.mcdragonlib.util.time.DLTime;
-// import de.mrjulsen.mcdragonlib.util.time.ITimeSystem;
-// import de.mrjulsen.mcdragonlib.util.time.TimeContext;
-import de.mrjulsen.mcdragonlib.util.TimeUtils;
+import de.mrjulsen.crn.util.ETimeFormat;
+import de.mrjulsen.mcdragonlib.util.time.ConfiguredTimeSystem;
+import de.mrjulsen.mcdragonlib.util.time.DLTime;
+import de.mrjulsen.mcdragonlib.util.time.ITimeSystem;
+import de.mrjulsen.mcdragonlib.util.time.TimeContext;
 import purplecreate.tramways.content.announcements.info.TrainInfo.PropertyGetter;
 
 import java.util.HashMap;
@@ -37,14 +36,14 @@ public class CRNTrainInfo implements PropertyGetter {
       props.put("group", group == null ? "" : group.getCategoryName());
       props.put("line", line == null ? "" : line.getLineName());
 
-      // dragonlib3
-      // ITimeSystem timeSystem = new ConfiguredTimeSystem();
+      ITimeSystem timeSystem = ConfiguredTimeSystem.INSTANCE;
+      long arrivalTicks = trainPrediction == null ? 0 : trainPrediction.scheduled().arrivalTime();
+      long departureTicks = trainPrediction == null ? 0 : trainPrediction.scheduled().departureTime();
 
-      // String arrivalTime = DLTime.fromTicks(trainPrediction == null ? 0 : trainPrediction.scheduled().arrivalTime(), timeSystem).format(ETimeFormat.HOURS_24.getFormat(), TimeContext.INGAME);
-      // String departureTime = DLTime.fromTicks(trainPrediction == null ? 0 : trainPrediction.scheduled().departureTime(), timeSystem).format(ETimeFormat.HOURS_24.getFormat(), TimeContext.INGAME);
-
-      String arrivalTime = TimeUtils.formatTime(trainPrediction == null ? 0 : trainPrediction.scheduled().arrivalTime(), TimeUtils.TimeFormat.HOURS_24);
-      String departureTime = TimeUtils.formatTime(trainPrediction == null ? 0 : trainPrediction.scheduled().departureTime(), TimeUtils.TimeFormat.HOURS_24);
+      String arrivalTime = DLTime.fromGameTicks(arrivalTicks, timeSystem)
+        .format(ETimeFormat.HOURS_24.getFormat(), TimeContext.INGAME, timeSystem);
+      String departureTime = DLTime.fromGameTicks(departureTicks, timeSystem)
+        .format(ETimeFormat.HOURS_24.getFormat(), TimeContext.INGAME, timeSystem);
       props.put("arrival_time", arrivalTime);
       props.put("departure_time", departureTime);
       props.put("arrival_time_hours", arrivalTime.split(":")[0]);

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 minecraft_version=1.21.1
 enabled_platforms=neoforge
 
-neoforge_version=21.1.215
+neoforge_version=21.1.219
 
 fabric_loader_version=0.18.4
 fabric_api_version=0.116.4+1.21.1
@@ -14,22 +14,21 @@ fabric_api_version=0.116.4+1.21.1
 mixin_extras_version=0.3.5
 
 # Create
-create_forge_version=6.0.9-215
-ponder_forge_version=1.0.81
+create_forge_version=6.0.10-280
+ponder_forge_version=1.0.82
 flywheel_forge_version=1.0.6
 registrate_forge_version=MC1.21-1.3.0+67
 
 create_fabric_version = 6.0.8.1+build.1744
 
-create_forge_version_range=[6.0.6,)
+create_forge_version_range=[6.0.10,6.1.0)
 create_fabric_version_range=>=6.0.7
 
 # Compat
 railways_common_version=1.6.14-beta+common-mc1.20.1-build.1593
 
-# its neoforge actually!
-crn_fabric_version=PrbRAPGr
-dragonlib_version=2.2.24
+crn_neoforge_version=hjpv7klQ
+dragonlib_version=beta-3.0.28
 
 # Mappings
 parchment_version=2024.11.17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
-networkTimeout=10000
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+networkTimeout=60000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -56,7 +56,7 @@ processResources {
   Map<String, String> properties = Map.of(
     "mod_id", mod_id,
     "version", mod_version,
-    "neoforge_version", neoforge_version.split("\\.")[0],
+    "neoforge_version", neoforge_version,
     "minecraft_version", minecraft_version,
     "create_version", create_forge_version.split("-")[0],
     "create_version_range", create_forge_version_range,


### PR DESCRIPTION
## Summary

- update the NeoForge 1.21.1 port to the official Create 6.0.10 development artifact and its required NeoForge/Ponder versions
- pin Java 21 and reproducible Architectury Loom, Architectury Plugin, Machete, and Gradle wrapper inputs
- fix block tag data generation against the current Create/NeoForge API
- update Create Railways Navigator compatibility to CRN 0.9.1 and DragonLib 3
- make the release workflow NeoForge-only and run it on Java 21

## Why

The existing `1.21.1/dev` branch targets Create 6.0.9 and pins NeoForge and Ponder versions below the minimum required by the latest public Create 6.0.10 release. Its CI workflow also runs on Java 17 even though Minecraft 1.21.1 requires Java 21.

The root project additionally produced a 261-byte jar containing only a manifest. That artifact can easily be mistaken for the installable mod and is rejected by FML as "not a valid mod file". This change disables the empty root artifacts and copies the final `remapJar` output to an unambiguous `dist` path.

## Validation

- `gradlew clean build --no-daemon` on Java 21
- final production jar recognized and loaded in a clean NeoForge 21.1.219 server with the public Create 6.0.10 release
- server completed startup to `Done` and shut down cleanly
- additional server smoke test on NeoForge 21.1.235
- Gradle wrapper SHA-256 verified against the official Gradle 8.12.1 checksum
